### PR TITLE
Compile GDAL with OpenJPEG driver

### DIFF
--- a/2.2.2/Dockerfile
+++ b/2.2.2/Dockerfile
@@ -10,11 +10,13 @@ MAINTAINER Cayetano Benavent <cayetano.benavent@geographica.gs>
 
 ENV ROOTDIR /usr/local/
 ENV GDAL_VERSION 2.2.2
+ENV OPENJPEG_VERSION 2.2.0
 
 # Load assets
 WORKDIR $ROOTDIR/
 
 ADD http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz $ROOTDIR/src/
+ADD https://github.com/uclouvain/openjpeg/archive/v2.2.0.tar.gz $ROOTDIR/src/openjpeg-${OPENJPEG_VERSION}.tar.gz
 
 # Install basic dependencies
 RUN apt-get update -y && apt-get install -y \
@@ -39,11 +41,19 @@ RUN apt-get update -y && apt-get install -y \
     libhdf4-alt-dev \
     libhdf5-serial-dev \
     wget \
-    bash-completion
+    bash-completion \
+    cmake
+
+# Compile and install OpenJPEG
+RUN cd src && tar -xvf openjpeg-${OPENJPEG_VERSION}.tar.gz && cd openjpeg-${OPENJPEG_VERSION}/ \
+    && mkdir build && cd build \
+    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$ROOTDIR \
+    && make && make install && make clean \
+    && cd $ROOTDIR && rm -Rf src/openjpeg*
 
 # Compile and install GDAL
 RUN cd src && tar -xvf gdal-${GDAL_VERSION}.tar.gz && cd gdal-${GDAL_VERSION} \
-    && ./configure --with-python --with-spatialite --with-pg --with-curl \
+    && ./configure --with-python --with-spatialite --with-pg --with-curl --with-openjpeg=$ROOTDIR \
     && make && make install && ldconfig \
     && apt-get update -y \
     && apt-get remove -y --purge build-essential wget \


### PR DESCRIPTION
### Overview

Adds support for JPEG2000 datasets by compiling GDAL with OpenJPEG
driver. Commands are based on these installation instructions:

* https://github.com/uclouvain/openjpeg/blob/master/INSTALL.md
* https://wiki.orfeo-toolbox.org/index.php/JPEG2000_with_GDAL_OpenJpeg_plugin

### Testing

Build Docker image:
```
$ docker build -t geographica/gdal2:2.2.2 .
```
Verify that OpenJPEG driver is enabled:
```
$ docker run --rm -it geographica/gdal2:2.2.2 | grep JPEG
  JPEG -raster- (rwv): JPEG JFIF
  JP2OpenJPEG -raster,vector- (rwv): JPEG-2000 driver based on OpenJPEG library
  JP2OpenJPEG -raster,vector- (rwv): JPEG-2000 driver based on OpenJPEG library
```
